### PR TITLE
Downgrade rubocop-ast to 0.3.0

### DIFF
--- a/solidus_affirm_v2.gemspec
+++ b/solidus_affirm_v2.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
+  spec.add_development_dependency 'rubocop-ast', '0.3.0'
   spec.add_development_dependency 'solidus_dev_support'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
0.4.0 is causing errors with Layout/LineLength:

```
55 errors occurred:
An error occurred while Layout/LineLength cop was inspecting
....
....
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.87.1 (using Parser 2.7.1.4, rubocop-ast 0.4.0, running on ruby 2.5.6 x86_64-linux)
```

Downgrading to 0.3.0 is fixing the errors above