### PR TITLE
Require ruby >= 2.5

### DIFF
--- a/solidus_affirm_v2.gemspec
+++ b/solidus_affirm_v2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_affirm_v2'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_affirm_v2/releases'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.4')
+  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/solidus_affirm_v2.gemspec
+++ b/solidus_affirm_v2.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
-  spec.add_development_dependency 'rubocop-ast', '0.3.0'
   spec.add_development_dependency 'solidus_dev_support'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Rubocop checks for supported ruby versions, since `2.4` is EOL we support
`>= 2.5` as well.