### PR TITLE
Fix transaction flow

### DIFF
--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -13,7 +13,7 @@ module SolidusAffirmV2
     end
 
     def authorize(_money, affirm_source, _options = {})
-      response = ::Affirm::Client.new.authorize(affirm_source.transaction_id)
+      response = ::Affirm::Client.new.authorize(affirm_source.checkout_token)
       ActiveMerchant::Billing::Response.new(true, "Transaction Approved", {}, authorization: response.id)
     rescue Affirm::Error => e
       ActiveMerchant::Billing::Response.new(false, e.message)


### PR DESCRIPTION
This PR replaces #13 which was opened accidentally with an extra commit.

These two commits fix the authorization flow to allow the transaction_id to be stored on the payment source.

Another way of saying it is that these changes avoid making the call to get_transaction, which fails if executed before the checkout is authorized (because we cannot pass in a transaction_id since we don't yet have one).