### PR TITLE
Solidus 3 preparation

### DIFF
--- a/app/serializers/solidus_affirm_v2/address_serializer.rb
+++ b/app/serializers/solidus_affirm_v2/address_serializer.rb
@@ -7,10 +7,18 @@ module SolidusAffirmV2
     attributes :name, :address
 
     def name
-      {
-        first: object.firstname,
-        last: object.lastname
-      }
+      if SolidusSupport.combined_first_and_last_name_in_address?
+        full_name = Spree::Address::Name.new(object.name)
+        {
+          first: full_name.first_name,
+          last: full_name.last_name
+        }
+      else
+        {
+          first: object.first_name,
+          last: object.last_name
+        }
+      end
     end
 
     def address

--- a/lib/solidus_affirm_v2/factories/address_factory.rb
+++ b/lib/solidus_affirm_v2/factories/address_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.modify do
+  factory :address do
+    if SolidusSupport.combined_first_and_last_name_in_address?
+      transient do
+        firstname { "John" }
+        lastname { "Doe" }
+      end
+
+      name { "#{firstname} #{lastname}" }
+    end
+  end
+end

--- a/solidus_affirm_v2.gemspec
+++ b/solidus_affirm_v2.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'active_model_serializers', '~> 0.10'
   spec.add_dependency 'affirm-ruby-api', '~> 1.0'
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support'

--- a/spec/serializers/solidus_affirm_v2/line_item_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm_v2/line_item_serializer_spec.rb
@@ -28,23 +28,19 @@ RSpec.describe SolidusAffirmV2::LineItemSerializer do
 
   describe "item_image_url" do
     context "with variant specific image" do
-      before do
-        allow(line_item.variant).to receive(:images).and_return([create(:image)]).twice
-      end
 
       it "will return the variant image url" do
-        expect(serialized_line_item_json["item_image_url"]).to match %r{/spree/products/\d/large/blank.jpg\?\d*}
+        expect(line_item.variant).to receive(:images).and_return([create(:image)]).twice
+        expect(subject['item_image_url']).to match /(blank|thinking-cat).jpg/
       end
     end
 
     context "when the variant does not have an image" do
-      before do
-        allow(line_item.variant).to receive(:images).and_return([])
-        allow(line_item.variant.product).to receive(:images).and_return([create(:image)]).twice
-      end
+      before { allow(line_item.variant).to receive(:images).and_return([]) }
 
       it "will return the master product image url" do
-        expect(serialized_line_item_json["item_image_url"]).to match %r{/spree/products/\d/large/blank.jpg\?\d*}
+        expect(line_item.variant.product).to receive(:images).and_return([create(:image)]).twice
+        expect(subject['item_image_url']).to match /(blank|thinking-cat).jpg/
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,10 @@ require 'solidus_affirm_v2/factories'
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+
+  if defined?(ActiveStorage::Current)
+    config.before(:all) do
+      ActiveStorage::Current.host = 'https://www.example.com'
+    end
+  end
 end


### PR DESCRIPTION
This PR prepares the extension for Solidus 3.0 by removing depreciations that would become errors in the updated version.
Tested against 2.10, 2.11, and 3.0

This fulfills issue #12 