### PR TITLE
Fix checkout flow

### DIFF
--- a/app/controllers/spree/affirm_v2/callback_controller.rb
+++ b/app/controllers/spree/affirm_v2/callback_controller.rb
@@ -18,12 +18,10 @@ module Spree
           return redirect_to spree.order_path(order), notice: "Order is already in complete state"
         end
 
-        affirm_transaction_object = payment_method.gateway.get_transaction(checkout_token)
+        affirm_checkout_object = payment_method.gateway.get_checkout(checkout_token)
 
         affirm_source_transaction = SolidusAffirmV2::Transaction.new(
-          transaction_id: affirm_transaction_object.id,
-          checkout_token: affirm_transaction_object.checkout_id,
-          provider: affirm_transaction_object.provider
+          checkout_token: checkout_token
         )
 
         affirm_source_transaction.transaction do
@@ -32,7 +30,7 @@ module Spree
               {
                 payment_method_id: affirm_params[:payment_method_id],
                 source: affirm_source_transaction,
-                amount: affirm_transaction_object.amount / 100.0
+                amount: affirm_checkout_object.total / 100.0
               }
             )
             order.next! unless order.state == "confirm"

--- a/app/helpers/solidus_affirm_v2/affirm_helper.rb
+++ b/app/helpers/solidus_affirm_v2/affirm_helper.rb
@@ -3,7 +3,6 @@
 module SolidusAffirmV2
   module AffirmHelper
     def affirm_js_setup(public_api_key, javascript_url)
-      # rubocop:disable Layout/LineLength
       output = %(
         var _affirm_config = {
           public_api_key: "#{public_api_key}",
@@ -11,7 +10,6 @@ module SolidusAffirmV2
         };
         (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");
       )
-      # rubocop:enable Layout/LineLength
       javascript_tag output
     end
 

--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -62,8 +62,8 @@ module SolidusAffirmV2
       end
     end
 
-    def get_transaction(checkout_token)
-      ::Affirm::Client.new.read_transaction(checkout_token)
+    def get_transaction(transaction_id)
+      ::Affirm::Client.new.read_transaction(transaction_id)
     end
   end
 end

--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -14,6 +14,11 @@ module SolidusAffirmV2
 
     def authorize(_money, affirm_source, _options = {})
       response = ::Affirm::Client.new.authorize(affirm_source.checkout_token)
+
+      SolidusAffirmV2::Transaction
+        .find_by(checkout_token: affirm_source.checkout_token)
+        .update(transaction_id: response.id)
+
       ActiveMerchant::Billing::Response.new(true, "Transaction Approved", {}, authorization: response.id)
     rescue Affirm::Error => e
       ActiveMerchant::Billing::Response.new(false, e.message)

--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -13,7 +13,7 @@ module SolidusAffirmV2
     end
 
     def authorize(_money, affirm_source, _options = {})
-      response = ::Affirm::Client.new.authorize(affirm_source.transaction_id)
+      response = ::Affirm::Client.new.authorize(affirm_source.checkout_token)
       ActiveMerchant::Billing::Response.new(true, "Transaction Approved", {}, authorization: response.id)
     rescue Affirm::Error => e
       ActiveMerchant::Billing::Response.new(false, e.message)
@@ -64,6 +64,10 @@ module SolidusAffirmV2
 
     def get_transaction(transaction_id)
       ::Affirm::Client.new.read_transaction(transaction_id)
+    end
+
+    def get_checkout(checkout_token)
+      ::Affirm::Client.new.get_checkout(checkout_token)
     end
   end
 end

--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -26,7 +26,7 @@ module SolidusAffirmV2
 
     def capture(_money, transaction_id, _options = {})
       _response = ::Affirm::Client.new.capture(transaction_id)
-      ActiveMerchant::Billing::Response.new(true, "Transaction Captured")
+      ActiveMerchant::Billing::Response.new(true, "Transaction Captured", authorization: transaction_id)
     rescue Affirm::Error => e
       ActiveMerchant::Billing::Response.new(false, e.message)
     end

--- a/app/models/solidus_affirm_v2/gateway.rb
+++ b/app/models/solidus_affirm_v2/gateway.rb
@@ -39,8 +39,8 @@ module SolidusAffirmV2
     end
 
     def credit(money, transaction_id, _options = {})
-      _response = ::Affirm::Client.new.refund(transaction_id, money)
-      ActiveMerchant::Billing::Response.new(true, "Transaction Credited with #{money}")
+      response = ::Affirm::Client.new.refund(transaction_id, money)
+      ActiveMerchant::Billing::Response.new(true, "Transaction Credited with #{money}", {}, authorization: response.id)
     rescue Affirm::Error => e
       ActiveMerchant::Billing::Response.new(false, e.message)
     end

--- a/app/serializers/solidus_affirm_v2/checkout_payload_serializer.rb
+++ b/app/serializers/solidus_affirm_v2/checkout_payload_serializer.rb
@@ -5,7 +5,7 @@ require "active_model_serializers"
 module SolidusAffirmV2
   class CheckoutPayloadSerializer < ActiveModel::Serializer
     attributes :merchant, :shipping, :billing, :items, :discounts, :metadata,
-                :order_id, :shipping_amount, :tax_amount, :total
+      :order_id, :shipping_amount, :tax_amount, :total
 
     def merchant
       hsh = {

--- a/app/serializers/solidus_affirm_v2/checkout_payload_serializer.rb
+++ b/app/serializers/solidus_affirm_v2/checkout_payload_serializer.rb
@@ -4,10 +4,8 @@ require "active_model_serializers"
 
 module SolidusAffirmV2
   class CheckoutPayloadSerializer < ActiveModel::Serializer
-    # rubocop:disable Layout/ArgumentAlignment
     attributes :merchant, :shipping, :billing, :items, :discounts, :metadata,
                 :order_id, :shipping_amount, :tax_amount, :total
-    # rubocop:enable Layout/ArgumentAlignment
 
     def merchant
       hsh = {

--- a/lib/generators/solidus_affirm_v2/install/install_generator.rb
+++ b/lib/generators/solidus_affirm_v2/install/install_generator.rb
@@ -11,8 +11,8 @@ module SolidusAffirmV2
       end
 
       def add_stylesheets
-        inject_into_file "vendor/assets/stylesheets/spree/frontend/all.css", " *= require spree/frontend/solidus_affirm_v2\n", before: %r{\*/}, verbose: true # rubocop:disable Layout/LineLength
-        inject_into_file "vendor/assets/stylesheets/spree/backend/all.css", " *= require spree/backend/solidus_affirm_v2\n", before: %r{\*/}, verbose: true # rubocop:disable Layout/LineLength
+        inject_into_file "vendor/assets/stylesheets/spree/frontend/all.css", " *= require spree/frontend/solidus_affirm_v2\n", before: %r{\*/}, verbose: true
+        inject_into_file "vendor/assets/stylesheets/spree/backend/all.css", " *= require spree/backend/solidus_affirm_v2\n", before: %r{\*/}, verbose: true
       end
 
       def add_migrations
@@ -20,11 +20,11 @@ module SolidusAffirmV2
       end
 
       def run_migrations
-        run_migrations = options[:auto_run_migrations] || ["", "y", "Y"].include?(ask("Would you like to run the migrations now? [Y/n]")) # rubocop:disable Layout/LineLength
+        run_migrations = options[:auto_run_migrations] || ["", "y", "Y"].include?(ask("Would you like to run the migrations now? [Y/n]"))
         if run_migrations
           run "bin/rails db:migrate"
         else
-          puts "Skipping bin/rails db:migrate, don't forget to run it!" # rubocop:disable Rails/Output
+          puts "Skipping bin/rails db:migrate, don't forget to run it!"
         end
       end
     end

--- a/solidus_affirm_v2.gemspec
+++ b/solidus_affirm_v2.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = "info@peterberkenbosch.nl"
 
   spec.summary = "Solidus extension for using Affirm financing payments in your store"
-  spec.description = "Solidus extenstion that integrates your store with Affirm financing payments using the new Transaction API" # rubocop:disable Layout/LineLength
+  spec.description = "Solidus extenstion that integrates your store with Affirm financing payments using the new Transaction API"
   spec.homepage = "https://github.com/solidusio-contrib/solidus_affirm_v2"
   spec.license = "BSD-3-Clause"
 

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -6,18 +6,16 @@
 require "spec_helper"
 
 RSpec.describe SolidusAffirmV2::Gateway do
-  subject(:gateway) do
+  let(:gateway) {
     described_class.new(gateway_options)
-  end
-
-  let(:gateway_options) do
+  }
+  let(:gateway_options) {
     {
       public_api_key: "PUBLIC_API_KEY",
       private_api_key: "PRIVATE_API_KEY",
       test_mode: true
     }
-  end
-
+  }
   let(:checkout_token) { "TKLKJ71GOP9YSASU" }
   let(:transaction_id) { "N330-Z6D4" }
   let(:affirm_v2_transaction) { create(:affirm_v2_transaction, checkout_token: checkout_token) }
@@ -29,38 +27,42 @@ RSpec.describe SolidusAffirmV2::Gateway do
   describe "initialize" do
     before { gateway }
 
-    it "will set the public_api_key in Affirm config" do
+    it "sets the public_api_key in Affirm config" do
       expect(Affirm.config.public_api_key).to eql "PUBLIC_API_KEY"
     end
 
-    it "will set the private_api_key in Affirm config" do
+    it "sets the private_api_key in Affirm config" do
       expect(Affirm.config.private_api_key).to eql "PRIVATE_API_KEY"
     end
 
-    it "will set the config environment to sandbox" do
+    it "sets the config environment to sandbox" do
       expect(Affirm.config.environment).to be :sandbox
     end
   end
 
   describe "#authorize" do
+    subject { gateway.authorize(nil, affirm_v2_transaction) }
+
     let(:affirm_transaction_response) { Affirm::Struct::Transaction.new({id: transaction_id, provider_id: 2}) }
-    let(:am_response) { subject.authorize(nil, affirm_v2_transaction) }
 
     before do
-      allow_any_instance_of(::Affirm::Client).to receive(:authorize).and_return(affirm_transaction_response)
+      allow_any_instance_of(::Affirm::Client)
+        .to receive(:authorize)
+        .with(affirm_v2_transaction.transaction_id)
+        .and_return(affirm_transaction_response)
     end
 
     context "with valid data" do
-      it "will return successfull ActiveMerchant::Response" do
-        expect(am_response).to be_success
+      it "returns successfull ActiveMerchant::Response" do
+        expect(subject).to be_success
       end
 
-      it "will set the Affirm transaction_id" do
-        expect(am_response.authorization).to eql transaction_id
+      it "sets the Affirm transaction_id" do
+        expect(subject.authorization).to eql transaction_id
       end
 
-      it "will return a 'Transaction Approved' message" do
-        expect(am_response.message).to eql "Transaction Approved"
+      it "returns a 'Transaction Approved' message" do
+        expect(subject.message).to eql "Transaction Approved"
       end
     end
 
@@ -69,95 +71,114 @@ RSpec.describe SolidusAffirmV2::Gateway do
         allow_any_instance_of(::Affirm::Client).to receive(:authorize).and_raise(Affirm::RequestError, "The transaction has already been authorized.")
       end
 
-      it "will return an unsuccesfull ActiveMerchant::Response" do
-        expect(am_response).not_to be_success
+      it "returns an unsuccesfull ActiveMerchant::Response" do
+        expect(subject).not_to be_success
       end
 
-      it "will return the error message from Affirm in the response" do
-        expect(am_response.message).to eql "The transaction has already been authorized."
+      it "returns the error message from Affirm in the response" do
+        expect(subject.message).to eql "The transaction has already been authorized."
       end
     end
   end
 
   describe "#capture" do
-    let(:am_response) { subject.capture(nil, transaction_id) }
+    subject { gateway.capture(nil, transaction_id) }
 
     before do
-      allow_any_instance_of(::Affirm::Client).to receive(:capture).with(transaction_id).and_return(affirm_transaction_event_response)
+      allow_any_instance_of(::Affirm::Client)
+        .to receive(:capture)
+        .with(transaction_id)
+        .and_return(affirm_transaction_event_response)
     end
 
-    it "will capture the affirm payment with the transaction_id" do
-      expect(am_response).to be_success
+    it "captures the affirm payment with the transaction_id" do
+      expect(subject).to be_success
     end
 
     context "with invalid data" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:capture).with(transaction_id).and_raise(Affirm::RequestError.new("The transaction has already been captured."))
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:capture)
+          .with(transaction_id)
+          .and_raise(Affirm::RequestError.new("The transaction has already been captured."))
       end
 
-      it "will return an unsuccesfull response" do
-        expect(am_response).not_to be_success
+      it "returns an unsuccesfull response" do
+        expect(subject).not_to be_success
       end
 
-      it "will return the error message from Affirm in the response" do
-        expect(am_response.message).to eql "The transaction has already been captured."
+      it "returns the error message from Affirm in the response" do
+        expect(subject.message).to eql "The transaction has already been captured."
       end
     end
   end
 
   describe "#void" do
-    let(:am_response) { subject.void(transaction_id, nil) }
+    subject { gateway.void(transaction_id, nil) }
 
     context "with an authorized payment" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:void).with(transaction_id).and_return(affirm_transaction_event_response)
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:void)
+          .with(transaction_id)
+          .and_return(affirm_transaction_event_response)
       end
 
-      it "will void the payment in Affirm" do
-        expect(am_response.message).to eql "Transaction Voided"
+      it "voids the payment in Affirm" do
+        expect(subject.message).to eql "Transaction Voided"
       end
     end
 
     context "with a captured payment" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:void).with(transaction_id).and_raise(Affirm::RequestError.new("The transaction has already been captured."))
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:void)
+          .with(transaction_id)
+          .and_raise(Affirm::RequestError.new("The transaction has already been captured."))
       end
 
-      it "will return an unsuccesfull response" do
-        expect(am_response).not_to be_success
+      it "returns an unsuccesfull response" do
+        expect(subject).not_to be_success
       end
 
-      it "will return the error message from Affirm in the response" do
-        expect(am_response.message).to eql "The transaction has already been captured."
+      it "returns the error message from Affirm in the response" do
+        expect(subject.message).to eql "The transaction has already been captured."
       end
     end
   end
 
   describe "#credit" do
-    let(:am_response) { subject.credit(money, transaction_id, nil) }
+    subject { gateway.credit(money, transaction_id, nil) }
+
     let(:money) { 1000 }
 
-    context "with an captured payment" do
+    context "with a captured payment" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:refund).with(transaction_id, money).and_return(affirm_transaction_event_response)
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:refund)
+          .with(transaction_id, money)
+          .and_return(affirm_transaction_event_response)
       end
 
-      it "will refund a part or the whole payment amount" do
-        expect(am_response.message).to eql "Transaction Credited with #{money}"
+      it "refunds a part or the whole payment amount" do
+        expect(subject.message).to eql "Transaction Credited with #{money}"
       end
     end
 
     context "with an already voided payment" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:refund).with(transaction_id, money).and_raise(Affirm::RequestError.new("The transaction has been voided and cannot be refunded."))
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:refund)
+          .with(transaction_id, money)
+          .and_raise(Affirm::RequestError.new("The transaction has been voided and cannot be refunded."))
       end
 
-      it "will return an unsuccesfull response" do
-        expect(am_response).not_to be_success
+      it "returns an unsuccesfull response" do
+        expect(subject).not_to be_success
       end
 
-      it "will return the error message from Affirm in the response" do
-        expect(am_response.message).to eql "The transaction has been voided and cannot be refunded."
+      it "returns the error message from Affirm in the response" do
+        expect(subject.message).to eql "The transaction has been voided and cannot be refunded."
       end
     end
   end

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe SolidusAffirmV2::Gateway do
   }
   let(:checkout_token) { "TKLKJ71GOP9YSASU" }
   let(:transaction_id) { "N330-Z6D4" }
-  let(:affirm_v2_transaction) { create(:affirm_v2_transaction, checkout_token: checkout_token) }
 
   let(:affirm_transaction_event_response) do
     Affirm::Struct::Transaction::Event.new({})
@@ -41,6 +40,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
     subject { gateway.authorize(nil, affirm_v2_transaction) }
 
     let(:affirm_transaction_response) { Affirm::Struct::Transaction.new({id: transaction_id, provider_id: 2}) }
+    let(:affirm_v2_transaction) { create(:affirm_v2_transaction, transaction_id: nil, checkout_token:) }
 
     before do
       allow_any_instance_of(::Affirm::Client)
@@ -60,6 +60,12 @@ RSpec.describe SolidusAffirmV2::Gateway do
 
       it "returns a 'Transaction Approved' message" do
         expect(subject.message).to eql "Transaction Approved"
+      end
+
+      it "updates the transaction id on the transaction" do
+        expect { subject }
+          .to change { affirm_v2_transaction.reload.transaction_id }
+          .from(nil).to(transaction_id)
       end
     end
 

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
     before do
       allow_any_instance_of(::Affirm::Client)
         .to receive(:authorize)
-        .with(affirm_v2_transaction.transaction_id)
+        .with(checkout_token)
         .and_return(affirm_transaction_response)
     end
 
@@ -65,7 +65,10 @@ RSpec.describe SolidusAffirmV2::Gateway do
 
     context "with invalid data" do
       before do
-        allow_any_instance_of(::Affirm::Client).to receive(:authorize).and_raise(Affirm::RequestError, "The transaction has already been authorized.")
+        allow_any_instance_of(::Affirm::Client)
+          .to receive(:authorize)
+          .with(checkout_token)
+          .and_raise(Affirm::RequestError, "The transaction has already been authorized.")
       end
 
       it "returns an unsuccesfull ActiveMerchant::Response" do

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/AnyInstance
-# rubocop:disable Layout/LineLength
-
 require "spec_helper"
 
 RSpec.describe SolidusAffirmV2::Gateway do
@@ -183,6 +180,3 @@ RSpec.describe SolidusAffirmV2::Gateway do
     end
   end
 end
-
-# rubocop:enable RSpec/AnyInstance
-# rubocop:enable Layout/LineLength

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
     end
 
     context "with valid data" do
-      it "returns successfull ActiveMerchant::Response" do
+      it "returns successful ActiveMerchant::Response" do
         expect(subject).to be_success
       end
 
@@ -77,7 +77,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
           .and_raise(Affirm::RequestError, "The transaction has already been authorized.")
       end
 
-      it "returns an unsuccesfull ActiveMerchant::Response" do
+      it "returns an unsuccessful ActiveMerchant::Response" do
         expect(subject).not_to be_success
       end
 
@@ -109,7 +109,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
           .and_raise(Affirm::RequestError.new("The transaction has already been captured."))
       end
 
-      it "returns an unsuccesfull response" do
+      it "returns an unsuccessful response" do
         expect(subject).not_to be_success
       end
 
@@ -143,7 +143,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
           .and_raise(Affirm::RequestError.new("The transaction has already been captured."))
       end
 
-      it "returns an unsuccesfull response" do
+      it "returns an unsuccessful response" do
         expect(subject).not_to be_success
       end
 
@@ -184,7 +184,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
           .and_raise(Affirm::RequestError.new("The transaction has been voided and cannot be refunded."))
       end
 
-      it "returns an unsuccesfull response" do
+      it "returns an unsuccessful response" do
         expect(subject).not_to be_success
       end
 

--- a/spec/models/solidus_affirm_v2/gateway_spec.rb
+++ b/spec/models/solidus_affirm_v2/gateway_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SolidusAffirmV2::Gateway do
   let(:transaction_id) { "N330-Z6D4" }
 
   let(:affirm_transaction_event_response) do
-    Affirm::Struct::Transaction::Event.new({})
+    Affirm::Struct::Transaction::Event.new(id: transaction_id)
   end
 
   describe "initialize" do
@@ -168,6 +168,11 @@ RSpec.describe SolidusAffirmV2::Gateway do
 
       it "refunds a part or the whole payment amount" do
         expect(subject.message).to eql "Transaction Credited with #{money}"
+      end
+
+      it "includes the authorization in the return" do
+        expect(subject.authorization)
+          .to eq "N330-Z6D4"
       end
     end
 

--- a/spec/requests/spree/affirm_v2/callback_controller_spec.rb
+++ b/spec/requests/spree/affirm_v2/callback_controller_spec.rb
@@ -1,9 +1,6 @@
 require "spec_helper"
 require "affirm"
 
-# rubocop:disable RSpec/AnyInstance
-# rubocop:disable Layout/LineLength
-
 RSpec.describe Spree::AffirmV2::CallbackController do
   let(:order) { create(:order_with_totals) }
   let(:checkout_token) { "FOOBAR123" }
@@ -118,5 +115,3 @@ RSpec.describe Spree::AffirmV2::CallbackController do
     end
   end
 end
-# rubocop:enable RSpec/AnyInstance
-# rubocop:enable Layout/LineLength

--- a/spec/serializers/solidus_affirm_v2/checkout_payload_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm_v2/checkout_payload_serializer_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe SolidusAffirmV2::CheckoutPayloadSerializer do
       end
 
       it "will set the discount_display_name" do
-        expect(serialized_checkout_payload_json["discounts"]["promotion_total"]["discount_display_name"]).to eql "Total promotion discount" # rubocop:disable Layout/LineLength
+        expect(serialized_checkout_payload_json["discounts"]["promotion_total"]["discount_display_name"]).to eql "Total promotion discount"
       end
     end
   end

--- a/spec/views/spree/checkout/payment/affirm_v2_spec.rb
+++ b/spec/views/spree/checkout/payment/affirm_v2_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "payment/affirm_v2" do # rubocop:disable RSpec/DescribeClass
+RSpec.describe "payment/affirm_v2" do
   let(:payment_method) { create(:affirm_v2_payment_method) }
   let(:address) { create(:address, name: "John's D'o", zipcode: "58451") }
   let(:order) { create(:order_with_totals, shipping_address: address) }


### PR DESCRIPTION
The change that attempted to switch this so that it wouldn't authorize payments before the order was complete actually broke checkout. The fundamental issue was that transaction and checkout ids were used interchangeably even though they represent different kinds of objects.

This fixes things so that we use the correct names and use the correct type of object. I had to move around where certain things were being persisted based on when the transaction actually exists.

I think it doesn't make sense that we have a transaction object that has a checkout id on it. I think it would make more sense to have separate checkout and transaction models with a transaction belonging to a checkout. That would map more closely to how affirm actually works but the current setup works.

This carries out the intent of https://github.com/solidusio-contrib/solidus_affirm_v2/pull/14